### PR TITLE
Add label function backend

### DIFF
--- a/backend/api/generated.go
+++ b/backend/api/generated.go
@@ -57,32 +57,34 @@ const (
 	Priority GetTasksParamsSort = "priority"
 )
 
-// Task defines model for Task.
-
-// type Task struct {
-// 	CreatedAt   *time.Time    `json:"created_at,omitempty"`
-// 	Description *string       `json:"description,omitempty"`
-// 	EndDate     *time.Time    `json:"end_date,omitempty"`
-// 	Id          *int          `json:"id,omitempty"`
-// 	Name        *string       `json:"name,omitempty"`
-// 	Priority    *TaskPriority `json:"priority,omitempty"`
-// 	StartDate   *time.Time    `json:"start_date,omitempty"`
-// 	Status      *TaskStatus   `json:"status,omitempty"`
-// 	UpdatedAt   *time.Time    `json:"updated_at,omitempty"`
-// }
-
-type Task struct {
-    CreatedAt   *time.Time    `json:"created_at,omitempty" db:"created_at"`
-    Description *string       `json:"description,omitempty" db:"description"`
-    EndDate     *time.Time    `json:"end_date,omitempty" db:"end_date"`
-    Id          *int          `json:"id,omitempty" db:"id"`
-    Name        *string       `json:"name,omitempty" db:"name"`
-    Priority    *TaskPriority `json:"priority,omitempty" db:"priority"`
-    StartDate   *time.Time    `json:"start_date,omitempty" db:"start_date"`
-    Status      *TaskStatus   `json:"status,omitempty" db:"status"`
-    UpdatedAt   *time.Time    `json:"updated_at,omitempty" db:"updated_at"`
+// Label defines model for Label.
+type Label struct {
+	ID        int       `json:"id" db:"id"`
+	Name      string    `json:"name" db:"name"`
+	Color     string    `json:"color" db:"color"`
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 }
 
+// LabelInput defines model for LabelInput.
+type LabelInput struct {
+	Name  string `json:"name" db:"name"`
+	Color string `json:"color" db:"color"`
+}
+
+// Task defines model for Task.
+type Task struct {
+	CreatedAt   *time.Time    `json:"created_at,omitempty"`
+	Description *string       `json:"description,omitempty"`
+	EndDate     *time.Time    `json:"end_date,omitempty"`
+	Id          *int          `json:"id,omitempty"`
+	Labels      []Label       `json:"labels" db:"-"` // DBには直接対応しない
+	Name        *string       `json:"name,omitempty"`
+	Priority    *TaskPriority `json:"priority,omitempty"`
+	StartDate   *time.Time    `json:"start_date,omitempty"`
+	Status      *TaskStatus   `json:"status,omitempty"`
+	UpdatedAt   *time.Time    `json:"updated_at,omitempty"`
+}
 
 // TaskPriority defines model for Task.Priority.
 type TaskPriority string
@@ -121,27 +123,45 @@ type GetTasksParamsStatus string
 // GetTasksParamsSort defines parameters for GetTasks.
 type GetTasksParamsSort string
 
+// PutTasksIdLabelsJSONBody defines parameters for PutTasksIdLabels.
+type PutTasksIdLabelsJSONBody struct {
+	LabelIds *[]int `json:"label_ids,omitempty"`
+}
+
+// PostLabelsJSONRequestBody defines body for PostLabels for application/json ContentType.
+type PostLabelsJSONRequestBody = LabelInput
+
+// PutLabelsIdJSONRequestBody defines body for PutLabelsId for application/json ContentType.
+type PutLabelsIdJSONRequestBody = LabelInput
+
 // PostTasksJSONRequestBody defines body for PostTasks for application/json ContentType.
 type PostTasksJSONRequestBody = TaskInput
 
 // PutTasksIdJSONRequestBody defines body for PutTasksId for application/json ContentType.
 type PutTasksIdJSONRequestBody = TaskInput
 
+// PutTasksIdLabelsJSONRequestBody defines body for PutTasksIdLabels for application/json ContentType.
+type PutTasksIdLabelsJSONRequestBody PutTasksIdLabelsJSONBody
+
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9xUTW8TMRD9K9XAcUm2lNPe+JAgEkWV6K2qKhNPtm6ztmvPgqIoEuRUeqHqoQiBxAWB",
-	"uEAleoAD8GPShPIvkL1tNmG3TVuFHjit1x7P+M17b9pQV4lWEiVZiNpg66uYML9cZHbdfbVRGg0J9Lt1",
-	"g4yQrzByfw1lErcCzgivkUgQAqCWRojAkhEyhk4AHG3dCE1CSXepcI6Sr7gEZ88o+EgiIQljNG5fsgRL",
-	"S2gjlBHUcoco0wSiJbgn4lUIYF5w3nRV7qsnsFxSzBIzdM4HWmKU2tFqDxQ9dImQQwA1uWBUbNBaCOC2",
-	"SnQT3UFZ9VTzcza8M9xRj9awTi6LI7MmdUpFRqfPzn/HQrGjbkvIhvIwBTXdmevxzDyTLMYEJc3cXKhB",
-	"AI/RWN9amK2EldA9S2mUTAuIYK4SVuYgAM1o1b+zSsyu+1WMnivHFHPc1DhEcBdp0Qe4K4YlSGgsREtt",
-	"EK7CRoqmBccEHMMPjlw9jT6UF/Kf0TJnvDcqvQtc1yweL8uxwdImQTQbFIbDSUmsMlTaoqFYRyxQ0pLl",
-	"AAxaraTN7HQ9DP2cVJJQegqZ1k1R9yRW12zmsrzcuBmH9AvCxC+uGmxABFeq+aCuHk3pqh/RuTiZMazl",
-	"/xWxZtmELBfy2ASAweZ2f+utj7VpkjDTggh63Z+97rde93Pv2aeDr08P33/odXf6L3b7P156YytbotYF",
-	"ZYdyNbiRoqVbirfO1Z5J8LOh1vE4/uJhtjDdchgH398MNrcnQO3uZGE+IHNmtS14J8vrTFLEfMfve9Q1",
-	"foJNndtzAQp+1B5hkENEJsUSL+QUFgV34xSg/edbv1+9mwg0C3NUnjp3Lg1SOFWRXEjmhx+//NrfG5d5",
-	"Wqby9N/35tK9E54iqcHr/cHu3kRJZWE+/Z8AAAD//99yTzdmCgAA",
+	"H4sIAAAAAAAC/9xXUW8bRRD+K9XA4xFfKE/3BlQCSymKRN+qKNr6Js62d7ub3TmQFZ1UO0i0VSVKH1IK",
+	"SJEAgapKIRJ9ACHgx1xsmn+Bds+xz7mNHSdOkPq22tvdmfnmm/nmtqElUyUFCjIQbYNpbWLK3HKF3cHE",
+	"LpSWCjVxdNstmUhtF9RRCBEY0ly0IQ+gpZERxuuM7OcNqVO7gpgRvkM8RQjqd3hceYoLwjZquy9Yil4j",
+	"mYrnNJKPduSdu9gi+4qLrSlURvMEeIpTeQAatzKuMYbodnkqGD6z5jF+i5l7HrPnQC9G09JcEZfC6zCK",
+	"eN0+cPF8JBYw5ycnTN3ibY0bEMFbjTGDGkP6NErujJFnWrPO1LwqzaXm1LEfUWSpRfJj3t6EAG7yOE6s",
+	"tyvy8wqg47uGmKY5AzXEKDNVa59I+tQ+hDEE0BSrWrY1GgMBfChTlaD94LO+GEZaUpxCyMVn+Y3LQh1R",
+	"u8XFhnRhckrsN4vxtZtMsDamKOja+6tNCOAz1MZBC8tL4VJo3ZIKBVMcIri+FC5dhwAUo03nZ2NcCW10",
+	"ybKpYjY5zRgi+AhppTxhu4JRUpgyi++GYdldBKFwF5lSCW+5q427pkxuWUB1Diym/vwwTfALBg+e9B/t",
+	"ubMmS1OmOxBBsfOi2Hle7Lw8/P3+659/KXpP+1/t9v9+5jgjjQeHVWmqQGxlaOgDGXfmwmBmiGXF5JMt",
+	"mHSGeQ395VopweFf3w8ePPEGPNg9KLrPiu4Xo8iL3tPyvDs5pEFjm8d5+bClZh2GG26/BKIZ1znxXt2r",
+	"/sNHR89/8nv1+Mv+/rfOsb3mjaK7X/WuvGczMp2YPjfCxablzLyaHtCYYkyzFAm1gej2NnD7nq1IOG5l",
+	"VrdOUiCoeHxS0PK1AIa99gRts0mU/n/ehnWGDL57Ndg9mB/Q8l7JX2Lm3tQudssd8GO/laHujMEfdvEq",
+	"4Bdt535Dw9GqltdZ96rwneO6Yu1JszFusCwhiJaDOrVOecRITV6IRppbUXIPJGsL1ZNR+s8kJ25i9Uxz",
+	"JIkl3vo6t9D0/il6fxS9X4vu/lxac0zXyyjZ8WyWD0t2lrKMwpgiMeNQJ5XFpeaMwuKidq3qUlrkbLEa",
+	"BTFFtaqBzhapqw0pXChJzkXz1y9++/fVwSTNT5GmS8fmymsnnEKpKTJXpVRN1VztVOb0K50ehim68Ojr",
+	"Gf/XeTzZsuu/6WcZ9xc7cFSY/PJo94ej+z8e/vlN0f266D0seo+L7p53AMnz/wIAAP//IgFxxXkSAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -97,6 +97,90 @@ paths:
       responses:
         "204":
           description: タスク削除成功
+  /labels:
+    get:
+      summary: ラベル一覧を取得
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  labels:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Label"
+    post:
+      summary: 新しいラベルを作成
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LabelInput"
+      responses:
+        "201":
+          description: 作成成功
+
+  /labels/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      summary: 指定したIDのラベルを取得
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Label"
+    put:
+      summary: 指定したIDのラベルを更新
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LabelInput"
+      responses:
+        "200":
+          description: 更新成功
+    delete:
+      summary: 指定したIDのラベルを削除
+      responses:
+        "204":
+          description: 削除成功
+
+  /tasks/{id}/labels:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    put:
+      summary: タスクに関連付けられたラベルを更新
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                label_ids:
+                  type: array
+                  items:
+                    type: integer
+      responses:
+        "200":
+          description: 更新成功
+
 components:
   schemas:
     Task:
@@ -126,6 +210,10 @@ components:
         updated_at:
           type: string
           format: date-time
+        labels:
+          type: array
+          items:
+            $ref: "#/components/schemas/Label"
     TaskInput:
       type: object
       properties:
@@ -145,3 +233,29 @@ components:
         status:
           type: string
           enum: [NotStarted, InProgress, Completed]
+    Label:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        color:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    LabelInput:
+      type: object
+      required:
+        - name
+        - color
+      properties:
+        name:
+          type: string
+        color:
+          type: string

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -27,6 +27,15 @@ func main() {
 	router.HandleFunc("/tasks/{id:[0-9]+}", taskHandler.UpdateTask).Methods("PUT")
 	router.HandleFunc("/tasks/{id:[0-9]+}", taskHandler.DeleteTask).Methods("DELETE")
 
+	// ラベルハンドラーを初期化し、ルーターに追加
+	labelHandler := handlers.NewLabelHandler(db)
+	router.HandleFunc("/labels", labelHandler.GetLabels).Methods("GET")
+	router.HandleFunc("/labels", labelHandler.CreateLabel).Methods("POST")
+	router.HandleFunc("/labels/{id:[0-9]+}", labelHandler.GetLabel).Methods("GET")
+	router.HandleFunc("/labels/{id:[0-9]+}", labelHandler.UpdateLabel).Methods("PUT")
+	router.HandleFunc("/labels/{id:[0-9]+}", labelHandler.DeleteLabel).Methods("DELETE")
+	router.HandleFunc("/tasks/{id:[0-9]+}/labels", labelHandler.UpdateTaskLabels).Methods("PUT")
+
 	// CORSミドルウェアを適用
 	corsHandler := cors.New(cors.Options{
 		AllowedOrigins:   []string{"http://localhost:3000"},

--- a/backend/db/init.sql
+++ b/backend/db/init.sql
@@ -9,3 +9,25 @@ CREATE TABLE tasks (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE labels (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(50) NOT NULL,
+    color VARCHAR(10) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE task_labels (
+    task_id INTEGER REFERENCES tasks(id) ON DELETE CASCADE,
+    label_id INTEGER REFERENCES labels(id) ON DELETE CASCADE,
+    PRIMARY KEY (task_id, label_id)
+);
+
+-- サンプルラベルの作成
+INSERT INTO labels (name, color) VALUES 
+    ('重要', '#FF5252'), 
+    ('仕事', '#4CAF50'), 
+    ('個人', '#2196F3'), 
+    ('勉強', '#9C27B0'),
+    ('家庭', '#FF9800');

--- a/backend/internal/handlers/label.go
+++ b/backend/internal/handlers/label.go
@@ -1,0 +1,202 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/yuchi1128/task-management-system/backend/api"
+)
+
+type LabelHandler struct {
+	db *sqlx.DB
+}
+
+func NewLabelHandler(db *sqlx.DB) *LabelHandler {
+	return &LabelHandler{db}
+}
+
+// ラベル一覧を取得
+func (h *LabelHandler) GetLabels(w http.ResponseWriter, r *http.Request) {
+	log.Println("Handling GetLabels request")
+
+	var labels []api.Label
+	err := h.db.Select(&labels, "SELECT * FROM labels ORDER BY name")
+	if err != nil {
+		log.Printf("Error fetching labels: %v", err)
+		http.Error(w, "Failed to fetch labels", http.StatusInternalServerError)
+		return
+	}
+
+	response := struct {
+		Labels []api.Label `json:"labels"`
+	}{
+		Labels: labels,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+// 新しいラベルを作成
+func (h *LabelHandler) CreateLabel(w http.ResponseWriter, r *http.Request) {
+	log.Println("Handling CreateLabel request")
+	var input api.LabelInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		log.Printf("Error decoding request body: %v", err)
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	var labelID int
+	err := h.db.QueryRow(
+		"INSERT INTO labels (name, color) VALUES ($1, $2) RETURNING id",
+		input.Name, input.Color,
+	).Scan(&labelID)
+
+	if err != nil {
+		log.Printf("Error creating label: %v", err)
+		http.Error(w, "Failed to create label", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+// IDのラベルを取得
+func (h *LabelHandler) GetLabel(w http.ResponseWriter, r *http.Request) {
+	log.Println("Handling GetLabel request")
+	idStr := r.URL.Path[len("/labels/"):]
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		log.Printf("Invalid label ID: %v", err)
+		http.Error(w, "Invalid label ID", http.StatusBadRequest)
+		return
+	}
+
+	var label api.Label
+	err = h.db.Get(&label, "SELECT * FROM labels WHERE id = $1", id)
+	if err != nil {
+		log.Printf("Error fetching label: %v", err)
+		http.Error(w, "Label not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(label)
+}
+
+// 指定したIDのラベルを更新
+func (h *LabelHandler) UpdateLabel(w http.ResponseWriter, r *http.Request) {
+	log.Println("Handling UpdateLabel request")
+	idStr := r.URL.Path[len("/labels/"):]
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		log.Printf("Invalid label ID: %v", err)
+		http.Error(w, "Invalid label ID", http.StatusBadRequest)
+		return
+	}
+
+	var input api.LabelInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		log.Printf("Error decoding request body: %v", err)
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	_, err = h.db.Exec(
+		"UPDATE labels SET name = $1, color = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $3",
+		input.Name, input.Color, id,
+	)
+	if err != nil {
+		log.Printf("Error updating label: %v", err)
+		http.Error(w, "Failed to update label", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// 指定したIDのラベルを削除
+func (h *LabelHandler) DeleteLabel(w http.ResponseWriter, r *http.Request) {
+	log.Println("Handling DeleteLabel request")
+	idStr := r.URL.Path[len("/labels/"):]
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		log.Printf("Invalid label ID: %v", err)
+		http.Error(w, "Invalid label ID", http.StatusBadRequest)
+		return
+	}
+
+	_, err = h.db.Exec("DELETE FROM labels WHERE id = $1", id)
+	if err != nil {
+		log.Printf("Error deleting label: %v", err)
+		http.Error(w, "Failed to delete label", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// タスクに関連付けられたラベルを更新
+func (h *LabelHandler) UpdateTaskLabels(w http.ResponseWriter, r *http.Request) {
+	log.Println("Handling UpdateTaskLabels request")
+
+	// タスクID取得
+	pathParts := r.URL.Path[len("/tasks/"):]
+	taskIDStr := pathParts[:len(pathParts)-len("/labels")]
+	taskID, err := strconv.Atoi(taskIDStr)
+	if err != nil {
+		log.Printf("Invalid task ID: %v", err)
+		http.Error(w, "Invalid task ID", http.StatusBadRequest)
+		return
+	}
+
+	// リクエストボディ取得
+	var input struct {
+		LabelIDs []int `json:"label_ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		log.Printf("Error decoding request body: %v", err)
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// トランザクション開始
+	tx, err := h.db.Beginx()
+	if err != nil {
+		log.Printf("Error starting transaction: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback()
+
+	// 既存のラベル関連を削除
+	_, err = tx.Exec("DELETE FROM task_labels WHERE task_id = $1", taskID)
+	if err != nil {
+		log.Printf("Error deleting task labels: %v", err)
+		http.Error(w, "Failed to update task labels", http.StatusInternalServerError)
+		return
+	}
+
+	// 新しいラベル関連を追加
+	for _, labelID := range input.LabelIDs {
+		_, err = tx.Exec("INSERT INTO task_labels (task_id, label_id) VALUES ($1, $2)", taskID, labelID)
+		if err != nil {
+			log.Printf("Error inserting task label: %v", err)
+			http.Error(w, "Failed to update task labels", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// トランザクション確定
+	if err = tx.Commit(); err != nil {
+		log.Printf("Error committing transaction: %v", err)
+		http.Error(w, "Failed to update task labels", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12,6 +12,7 @@
   --font-mono: var(--font-geist-mono);
 }
 
+/* ダークモード設定もライトモードと同じ値に固定 */
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #ffffff;
@@ -23,4 +24,24 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+/* MUIコンポーネント用のカラーオーバーライド */
+.MuiPaper-root {
+  background-color: #ffffff !important;
+  color: #171717 !important;
+}
+
+.MuiDialog-paper {
+  background-color: #ffffff !important;
+}
+
+.MuiInputBase-input {
+  color: #171717 !important;
+}
+
+/* テーブルの背景色と文字色を固定 */
+.MuiDataGrid-root {
+  background-color: #ffffff !important;
+  color: #171717 !important;
 }


### PR DESCRIPTION
# ラベル機能のバックエンド実装

## 概要
タスク管理システムに**ラベル機能**のバックエンド実装を追加しました。  

---

## 実装内容

### データモデル
- `labels` テーブルの作成  
  - カラム: `id`, `name`, `color`, `created_at`, `updated_at`
- `task_labels` 中間テーブルの作成  
  - 多対多関係: `task_id` と `label_id`

### API エンドポイント
| メソッド | パス                     | 説明                              |
|----------|--------------------------|-----------------------------------|
| GET      | `/labels`                | ラベル一覧を取得                  |
| POST     | `/labels`                | 新しいラベルを作成                |
| GET      | `/labels/{id}`           | 特定のラベルを取得                |
| PUT      | `/labels/{id}`           | 特定のラベルを更新                |
| DELETE   | `/labels/{id}`           | 特定のラベルを削除                |
| PUT      | `/tasks/{id}/labels`     | タスクに関連付けるラベルを更新    |