### PR TITLE
Add label function frontend

### DIFF
--- a/frontend/src/app/labels/page.tsx
+++ b/frontend/src/app/labels/page.tsx
@@ -114,7 +114,7 @@ export default function LabelsPage() {
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Typography variant="h4" sx={{ fontWeight: 'bold' }}>
+        <Typography variant="h4" sx={{ flex: 1, fontWeight: 'bold', fontSize: 25 }}>
           ラベル管理
         </Typography>
         <Button

--- a/frontend/src/app/labels/page.tsx
+++ b/frontend/src/app/labels/page.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Container,
+  Typography,
+  Box,
+  Button,
+  TextField,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  IconButton,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import { getLabels, createLabel, updateLabel, deleteLabel, Label, LabelInput } from '@/lib/api';
+
+export default function LabelsPage() {
+  const queryClient = useQueryClient();
+  const [openDialog, setOpenDialog] = useState(false);
+  const [editingLabel, setEditingLabel] = useState<Label | null>(null);
+  const [formData, setFormData] = useState<LabelInput>({
+    name: '',
+    color: '#2196F3',
+  });
+
+  // ラベル一覧を取得
+  const { data: labels, isLoading, error } = useQuery({
+    queryKey: ['labels'],
+    queryFn: getLabels,
+  });
+
+  // ラベル作成
+  const createMutation = useMutation({
+    mutationFn: createLabel,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['labels'] });
+      handleCloseDialog();
+    },
+  });
+
+  // ラベル更新
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: LabelInput }) => updateLabel(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['labels'] });
+      handleCloseDialog();
+    },
+  });
+
+  // ラベル削除
+  const deleteMutation = useMutation({
+    mutationFn: deleteLabel,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['labels'] });
+    },
+  });
+
+  const handleOpenDialog = (label?: Label) => {
+    if (label) {
+      setEditingLabel(label);
+      setFormData({
+        name: label.name,
+        color: label.color,
+      });
+    } else {
+      setEditingLabel(null);
+      setFormData({
+        name: '',
+        color: '#2196F3',
+      });
+    }
+    setOpenDialog(true);
+  };
+
+  const handleCloseDialog = () => {
+    setOpenDialog(false);
+    setEditingLabel(null);
+    setFormData({
+      name: '',
+      color: '#2196F3',
+    });
+  };
+
+  const handleSubmit = () => {
+    if (editingLabel) {
+      updateMutation.mutate({ id: editingLabel.id, data: formData });
+    } else {
+      createMutation.mutate(formData);
+    }
+  };
+
+  const handleDelete = (id: number) => {
+    if (window.confirm('このラベルを削除してもよろしいですか？')) {
+      deleteMutation.mutate(id);
+    }
+  };
+
+  const colorOptions = [
+    '#F44336', // 赤
+    '#FF9800', // オレンジ
+    '#FFEB3B', // 黄色
+    '#4CAF50', // 緑
+    '#2196F3', // 青
+    '#9C27B0', // 紫
+    '#795548', // 茶色
+    '#607D8B', // グレー
+  ];
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Typography variant="h4" sx={{ fontWeight: 'bold' }}>
+          ラベル管理
+        </Typography>
+        <Button
+          variant="contained"
+          onClick={() => handleOpenDialog()}
+          sx={{ bgcolor: '#e0e0e0', color: '#171717', '&:hover': { bgcolor: '#d0d0d0' } }}
+        >
+          新規ラベル作成
+        </Button>
+      </Box>
+
+      {isLoading ? (
+        <Typography>ローディング...</Typography>
+      ) : error ? (
+        <Typography color="error">エラーが発生しました</Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {labels && labels.map((label) => (
+            <Box 
+              key={label.id} 
+              sx={{ 
+                width: { xs: '100%', sm: 'calc(50% - 8px)', md: 'calc(33.333% - 10.67px)' } 
+              }}
+            >
+              <Paper
+                sx={{
+                  p: 2,
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  <Box
+                    sx={{
+                      width: 16,
+                      height: 16,
+                      borderRadius: '50%',
+                      bgcolor: label.color,
+                      mr: 1,
+                    }}
+                  />
+                  <Typography>{label.name}</Typography>
+                </Box>
+                <Box>
+                  <IconButton size="small" onClick={() => handleOpenDialog(label)}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => handleDelete(label.id)}>
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              </Paper>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <Dialog open={openDialog} onClose={handleCloseDialog}>
+        <DialogTitle>{editingLabel ? 'ラベルの編集' : 'ラベルの作成'}</DialogTitle>
+        <DialogContent>
+          <TextField
+            label="ラベル名"
+            value={formData.name}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            fullWidth
+            margin="dense"
+            required
+          />
+          
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>色の選択</Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              {colorOptions.map((color) => (
+                <Box
+                  key={color}
+                  onClick={() => setFormData({ ...formData, color })}
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: '50%',
+                    bgcolor: color,
+                    cursor: 'pointer',
+                    border: formData.color === color ? '2px solid #000' : 'none',
+                  }}
+                />
+              ))}
+            </Box>
+            <TextField
+              type="color"
+              label="カスタムカラー"
+              value={formData.color}
+              onChange={(e) => setFormData({ ...formData, color: e.target.value })}
+              fullWidth
+              margin="dense"
+              sx={{ mt: 1 }}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog}>キャンセル</Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={createMutation.isPending || updateMutation.isPending}
+          >
+            {editingLabel ? '更新' : '作成'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Container>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import Navigation from '@/components/Navigation';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -17,10 +18,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="ja">
       <body className={inter.className}>
         <QueryClientProvider client={queryClient}>
           <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Navigation />
             {children}
           </LocalizationProvider>
         </QueryClientProvider>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -27,6 +27,7 @@ export default function Home() {
     status: '',
     endDateFrom: null as Date | null,
     endDateTo: null as Date | null,
+    labelIds: [] as number[],
   });
 
   const [sortModel, setSortModel] = useState<GridSortModel>([
@@ -44,6 +45,7 @@ export default function Home() {
       status: '',
       endDateFrom: null,
       endDateTo: null,
+      labelIds: [],
     });
   };
 
@@ -52,7 +54,7 @@ export default function Home() {
     queryFn: getTasks,
   });
 
-  const handleSearchChange = (field: string, value: string | Date | null) => {
+  const handleSearchChange = (field: string, value: string | Date | null | number[]) => {
     setSearchParams((prev) => ({
       ...prev,
       [field]: value,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -111,8 +111,8 @@ export default function Home() {
   return (
     <Container sx={{ mt: 2, mb: 2 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-        <Typography variant="h4" sx={{ flex: 1, fontWeight: 'bold', fontSize: 30 }}>
-          TODOアプリ
+        <Typography variant="h4" sx={{ flex: 1, fontWeight: 'bold', fontSize: 25 }}>
+          タスク一覧
         </Typography>
         <Button
           variant="contained"

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { AppBar, Toolbar, Typography, Button } from '@mui/material';
+import { useRouter, usePathname } from 'next/navigation';
+
+export default function Navigation() {
+  const router = useRouter();
+  const pathname = usePathname();
+  
+  return (
+    <AppBar position="static" sx={{ bgcolor: '#fff', color: '#171717', boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}>
+      <Toolbar>
+        <Typography variant="h4" sx={{ flex: 1, fontWeight: 'bold', fontSize: 27 }}>
+          TODOアプリ
+        </Typography>
+        <Button 
+          color="inherit"
+          onClick={() => router.push('/')}
+          sx={{ 
+            mx: 1,
+            fontWeight: pathname === '/' ? 'bold' : 'normal',
+            borderBottom: pathname === '/' ? '2px solid #171717' : 'none'
+          }}
+        >
+          タスク一覧
+        </Button>
+        <Button 
+          color="inherit"
+          onClick={() => router.push('/labels')}
+          sx={{ 
+            mx: 1,
+            fontWeight: pathname === '/labels' ? 'bold' : 'normal',
+            borderBottom: pathname === '/labels' ? '2px solid #171717' : 'none'
+          }}
+        >
+          ラベル管理
+        </Button>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/frontend/src/components/TaskActions.tsx
+++ b/frontend/src/components/TaskActions.tsx
@@ -17,9 +17,11 @@ import {
   InputLabel,
   FormControl,
   Button,
+  Box,
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import TaskLabelSelector from './TaskLabelSelector';
 
 interface TaskActionsProps {
   task: Task;
@@ -67,9 +69,16 @@ export default function TaskActions({ task }: TaskActionsProps) {
 
   return (
     <>
-      <IconButton onClick={handleMenuOpen}>
-        <MoreVertIcon />
-      </IconButton>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <TaskLabelSelector 
+          taskId={task.id} 
+          selectedLabelIds={task.labels?.map(l => l.id) || []}
+          compact
+        />
+        <IconButton onClick={handleMenuOpen}>
+          <MoreVertIcon />
+        </IconButton>
+      </Box>
       <Menu
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}

--- a/frontend/src/components/TaskFilter.tsx
+++ b/frontend/src/components/TaskFilter.tsx
@@ -11,6 +11,11 @@ import {
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import { useQuery } from '@tanstack/react-query';
+import { getLabels, Label } from '@/lib/api';
+import Checkbox from '@mui/material/Checkbox';
+import FormGroup from '@mui/material/FormGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
 
 interface SearchParams {
   name: string;
@@ -19,11 +24,12 @@ interface SearchParams {
   status: string;
   endDateFrom: Date | null;
   endDateTo: Date | null;
+  labelIds?: number[];
 }
 
 interface TaskFilterProps {
   searchParams: SearchParams;
-  onSearchChange: (field: string, value: string | Date | null) => void;
+  onSearchChange: (field: string, value: string | Date | null | number[]) => void;
   onResetFilters: () => void;
 }
 
@@ -32,6 +38,17 @@ export default function TaskFilter({
   onSearchChange, 
   onResetFilters 
 }: TaskFilterProps) {
+  const { data: labels = [] } = useQuery({ queryKey: ['labels'], queryFn: getLabels });
+
+  const handleLabelToggle = (labelId: number) => {
+    const prev = searchParams.labelIds || [];
+    if (prev.includes(labelId)) {
+      onSearchChange('labelIds', prev.filter(id => id !== labelId));
+    } else {
+      onSearchChange('labelIds', [...prev, labelId]);
+    }
+  };
+
   return (
     <Box sx={{ mb: 1.5 }}>
       <Typography variant="subtitle2" sx={{ mb: 0.7, fontSize: 15 }}>
@@ -114,6 +131,25 @@ export default function TaskFilter({
             },
           }}
         />
+        <FormGroup row sx={{ alignItems: 'center', minWidth: 180 }}>
+          <Typography variant="body2" sx={{ mr: 1, color: '#888' }}>ラベル:</Typography>
+          {labels.map((label: Label) => (
+            <FormControlLabel
+              key={label.id}
+              control={
+                <Checkbox
+                  checked={searchParams.labelIds?.includes(label.id) || false}
+                  onChange={() => handleLabelToggle(label.id)}
+                  sx={{
+                    color: label.color,
+                    '&.Mui-checked': { color: label.color },
+                  }}
+                />
+              }
+              label={label.name}
+            />
+          ))}
+        </FormGroup>
         <Button
           variant="outlined"
           size="small"

--- a/frontend/src/components/TaskLabelSelector.tsx
+++ b/frontend/src/components/TaskLabelSelector.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  Button,
+  Popover,
+  Box,
+  Typography,
+  Checkbox,
+  FormControlLabel,
+  CircularProgress,
+} from '@mui/material';
+import LabelIcon from '@mui/icons-material/Label';
+import { getLabels, updateTaskLabels, Label } from '@/lib/api';
+
+interface TaskLabelSelectorProps {
+  taskId: number;
+  selectedLabelIds: number[];
+  compact?: boolean;
+}
+
+export default function TaskLabelSelector({ taskId, selectedLabelIds, compact = false }: TaskLabelSelectorProps) {
+  const queryClient = useQueryClient();
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const [selectedIds, setSelectedIds] = useState<number[]>(selectedLabelIds || []);
+  
+  const { data: labels, isLoading } = useQuery({
+    queryKey: ['labels'],
+    queryFn: getLabels,
+  });
+  
+  const updateMutation = useMutation({
+    mutationFn: (labelIds: number[]) => updateTaskLabels(taskId, labelIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      handleClose();
+    },
+  });
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleToggle = (labelId: number) => {
+    setSelectedIds(prev =>
+      prev.includes(labelId)
+        ? prev.filter(id => id !== labelId)
+        : [...prev, labelId]
+    );
+  };
+
+  const handleSave = () => {
+    updateMutation.mutate(selectedIds);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'label-popover' : undefined;
+
+  return (
+    <>
+      <Button
+        variant={compact ? "text" : "outlined"}
+        startIcon={<LabelIcon />}
+        onClick={handleClick}
+        size={compact ? "small" : "medium"}
+        sx={compact ? { minWidth: 0, p: 0.5 } : {}}
+      >
+        {compact ? '' : 'ラベル'}
+      </Button>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <Box sx={{ p: 2, width: 250 }}>
+          <Typography variant="subtitle1" sx={{ mb: 1 }}>ラベルを選択</Typography>
+          
+          {isLoading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : labels && labels.length > 0 ? (
+            <Box sx={{ maxHeight: 300, overflow: 'auto' }}>
+              {labels.map((label: Label) => (
+                <FormControlLabel
+                  key={label.id}
+                  control={
+                    <Checkbox
+                      checked={selectedIds.includes(label.id)}
+                      onChange={() => handleToggle(label.id)}
+                      sx={{
+                        color: label.color,
+                        '&.Mui-checked': {
+                          color: label.color,
+                        },
+                      }}
+                    />
+                  }
+                  label={label.name}
+                />
+              ))}
+            </Box>
+          ) : (
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              ラベルがありません
+            </Typography>
+          )}
+          
+          <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end' }}>
+            <Button onClick={handleClose} sx={{ mr: 1 }}>
+              キャンセル
+            </Button>
+            <Button 
+              variant="contained" 
+              onClick={handleSave}
+              disabled={updateMutation.isPending}
+            >
+              保存
+            </Button>
+          </Box>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/frontend/src/components/TaskTable.tsx
+++ b/frontend/src/components/TaskTable.tsx
@@ -38,6 +38,7 @@ export default function TaskTable({
           onSortModelChange={onSortModelChange}
           hideFooter
           disableColumnMenu
+          rowHeight={42}
         />
       </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,19 @@ const api: AxiosInstance = axios.create({
   },
 });
 
+export interface Label {
+  id: number;
+  name: string;
+  color: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LabelInput {
+  name: string;
+  color: string;
+}
+
 export interface Task {
   id: number;
   name: string;
@@ -20,6 +33,7 @@ export interface Task {
   status: 'NotStarted' | 'InProgress' | 'Completed';
   created_at: string;
   updated_at: string;
+  labels?: Label[];
 }
 
 export interface TaskInput {
@@ -31,7 +45,7 @@ export interface TaskInput {
   status: 'NotStarted' | 'InProgress' | 'Completed';
 }
 
-// APIメソッド
+// タスクのAPIメソッド
 export const getTasks = async (): Promise<Task[]> => {
   const response = await api.get('/tasks');
   return response.data.tasks;
@@ -52,4 +66,32 @@ export const updateTask = async (id: number, task: TaskInput): Promise<void> => 
 
 export const deleteTask = async (id: number): Promise<void> => {
   await api.delete(`/tasks/${id}`);
+};
+
+// ラベルのAPIメソッド
+export const getLabels = async (): Promise<Label[]> => {
+  const response = await api.get('/labels');
+  return response.data.labels;
+};
+
+export const createLabel = async (label: LabelInput): Promise<void> => {
+  await api.post('/labels', label);
+};
+
+export const getLabel = async (id: number): Promise<Label> => {
+  const response = await api.get(`/labels/${id}`);
+  return response.data;
+};
+
+export const updateLabel = async (id: number, label: LabelInput): Promise<void> => {
+  await api.put(`/labels/${id}`, label);
+};
+
+export const deleteLabel = async (id: number): Promise<void> => {
+  await api.delete(`/labels/${id}`);
+};
+
+// タスクにラベルを関連付ける
+export const updateTaskLabels = async (taskId: number, labelIds: number[]): Promise<void> => {
+  await api.put(`/tasks/${taskId}/labels`, { label_ids: labelIds });
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -51,8 +51,11 @@ export const getTasks = async (): Promise<Task[]> => {
   return response.data.tasks;
 };
 
-export const createTask = async (task: TaskInput): Promise<void> => {
-  await api.post('/tasks', task);
+export const createTask = async (task: TaskInput, labelIds?: number[]): Promise<void> => {
+  const response = await api.post('/tasks', task);
+  if (labelIds && labelIds.length > 0 && response.data && response.data.id) {
+    await updateTaskLabels(response.data.id, labelIds);
+  }
 };
 
 export const getTask = async (id: number): Promise<Task> => {

--- a/frontend/src/lib/columns.tsx
+++ b/frontend/src/lib/columns.tsx
@@ -23,40 +23,39 @@ export const getTaskColumns = (sortModel: GridSortModel): GridColDef[] => {
       width: 150,
       sortable: false,
     },
-    // 既存のカラムの後にラベルカラムを追加
     {
       field: 'labels',
       headerName: 'ラベル',
-      width: 150,
+      width: 210,
       sortable: false,
       renderCell: (params) => {
         const labels = params.value || [];
         return (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-            {labels.slice(0, 3).map((label: Label) => (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, maxHeight: 45, overflow: 'auto', py: 1 }}>
+            {labels.map((label: Label) => (
               <Box
                 key={label.id}
                 sx={{
                   bgcolor: label.color,
                   color: '#fff',
-                  fontSize: '0.7rem',
-                  px: 1,
-                  py: 0.25,
-                  borderRadius: 10,
+                  fontSize: '0.75rem',
+                  px: 0.7,
+                  py: 0.3,
+                  borderRadius: 2.5,
                   whiteSpace: 'nowrap',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
-                  maxWidth: 60,
+                  maxWidth: 55,
+                  height: '25px',
+                  lineHeight: '18px',
+                  marginBottom: '4px',
+                  display: 'inline-flex',
+                  alignItems: 'center'
                 }}
               >
                 {label.name}
               </Box>
             ))}
-            {labels.length > 3 && (
-              <Box sx={{ fontSize: '0.7rem', color: 'text.secondary' }}>
-                +{labels.length - 3}
-              </Box>
-            )}
           </Box>
         );
       }

--- a/frontend/src/lib/columns.tsx
+++ b/frontend/src/lib/columns.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
 import { GridColDef, GridSortModel } from '@mui/x-data-grid';
-import { Task } from '@/lib/api';
+import { Task, Label } from '@/lib/api';
 import TaskActions from '@/components/TaskActions';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
@@ -22,6 +22,44 @@ export const getTaskColumns = (sortModel: GridSortModel): GridColDef[] => {
       headerName: 'タスク名',
       width: 150,
       sortable: false,
+    },
+    // 既存のカラムの後にラベルカラムを追加
+    {
+      field: 'labels',
+      headerName: 'ラベル',
+      width: 150,
+      sortable: false,
+      renderCell: (params) => {
+        const labels = params.value || [];
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {labels.slice(0, 3).map((label: Label) => (
+              <Box
+                key={label.id}
+                sx={{
+                  bgcolor: label.color,
+                  color: '#fff',
+                  fontSize: '0.7rem',
+                  px: 1,
+                  py: 0.25,
+                  borderRadius: 10,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  maxWidth: 60,
+                }}
+              >
+                {label.name}
+              </Box>
+            ))}
+            {labels.length > 3 && (
+              <Box sx={{ fontSize: '0.7rem', color: 'text.secondary' }}>
+                +{labels.length - 3}
+              </Box>
+            )}
+          </Box>
+        );
+      }
     },
     {
       field: 'priority',

--- a/frontend/src/lib/taskUtils.ts
+++ b/frontend/src/lib/taskUtils.ts
@@ -21,7 +21,10 @@ export function multiSort(tasks: Task[], sortModel: GridSortModel) {
         aValue = priorityOrder[aValue as string] || 0;
         bValue = priorityOrder[bValue as string] || 0;
       }
-
+      
+      if (aValue === undefined && bValue === undefined) return 0;
+      if (aValue === undefined) return sort.sort === 'asc' ? -1 : 1;
+      if (bValue === undefined) return sort.sort === 'asc' ? 1 : -1;
       if (aValue < bValue) return sort.sort === 'asc' ? -1 : 1;
       if (aValue > bValue) return sort.sort === 'asc' ? 1 : -1;
     }

--- a/frontend/src/lib/taskUtils.ts
+++ b/frontend/src/lib/taskUtils.ts
@@ -41,6 +41,7 @@ export function filterTasks(
     status: string;
     endDateFrom: Date | null;
     endDateTo: Date | null;
+    labelIds?: number[];
   }
 ) {
   return tasks.filter((task) => {
@@ -74,6 +75,12 @@ export function filterTasks(
       }
     }
 
-    return basicFiltersPassed && dateFilterPassed;
+    let labelFilterPassed = true;
+    if (searchParams.labelIds && searchParams.labelIds.length > 0) {
+      const taskLabelIds = (task.labels || []).map(l => l.id);
+      labelFilterPassed = searchParams.labelIds.every(id => taskLabelIds.includes(id));
+    }
+
+    return basicFiltersPassed && dateFilterPassed && labelFilterPassed;
   });
 }


### PR DESCRIPTION
# ラベル機能のフロントエンド実装

## 概要
ラベル機能のフロントエンド側を実装

## 主な変更点

- `/labels` ページの追加（ラベルの一覧表示、新規作成、編集、削除が可能）

- タスク一覧ページとラベル管理ページを移動しやすくするためにナビゲーションバーを追加

- タスク作成・編集画面でのラベル選択UIの追加

- タスク一覧・詳細ページでのラベル表示

- ラベルでの検索を可能に
